### PR TITLE
Linking edit/delete room buttons w/ backend

### DIFF
--- a/src/Pages/EditRoom.jsx
+++ b/src/Pages/EditRoom.jsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setShowEditRoomPopup } from "../Reducers/showEditRoomPopupSlice";
 
 export const EditRoom = () => {
   const dispatch = useDispatch();
-  const user = useSelector((state) => state.user);
+  const room = useSelector((state) => state.room);
 
   // local state to prepare to send info to the database.
   const [roomInfo, setRoomInfo] = useState({
@@ -18,7 +18,7 @@ export const EditRoom = () => {
 
     const createRoomInfo = {
       ...roomInfo,
-      userID: user.id,
+      roomID: room.id,
     };
 
     const JSONroomInfo = JSON.stringify(createRoomInfo);
@@ -35,8 +35,8 @@ export const EditRoom = () => {
       requestOptions
     );
 
-    // refreshes the page to see the new room created
-    window.location.reload(false);
+    // // refreshes the page to see the new room editted. Commented out until the reducer refresh issue is solved.
+    // window.location.reload(false);
   };
 
   return (
@@ -73,7 +73,7 @@ export const EditRoom = () => {
             onChange={(e) => {
               setRoomInfo((roomInfo) => ({
                 ...roomInfo,
-                name: e.target.value,
+                image: e.target.value,
               }));
             }}
             className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"

--- a/src/Pages/ProfilePage.jsx
+++ b/src/Pages/ProfilePage.jsx
@@ -8,6 +8,7 @@ import { setRoomPopup } from "../Reducers/RoomPopupSlice";
 import { setUser } from "../Reducers/UserSlice";
 import { EditRoom } from "./EditRoom";
 import { setShowEditRoomPopup } from "../Reducers/showEditRoomPopupSlice";
+import { setRoom } from "../Reducers/RoomSlice";
 
 const ProfilePage = () => {
   const dispatch = useDispatch();
@@ -15,6 +16,7 @@ const ProfilePage = () => {
 
   // Getting the user info from state
   const user = useSelector((state) => state.user);
+  const room = useSelector((state) => state.room);
 
   // Redux state for pop-ups
   const ProfilePopup = useSelector((state) => state.ProfilePopup);
@@ -56,6 +58,29 @@ const ProfilePage = () => {
 
     //Navigate to home page.
     navigate("/");
+  };
+
+  // Deletes a room
+  const deleteRoom = async () => {
+    const myHeaders = new Headers();
+    myHeaders.append("Content-Type", "application/json");
+
+    const JSONroomInfo = JSON.stringify({ roomID: room.id });
+
+    const requestOptions = {
+      method: "DELETE",
+      headers: myHeaders,
+      body: JSONroomInfo,
+      redirect: "follow",
+    };
+
+    await fetch(
+      "https://plotpointsbackend.onrender.com/rooms/delete",
+      requestOptions
+    );
+
+    // // refreshes the page to see the new room editted
+    // window.location.reload(false);
   };
 
   return (
@@ -244,11 +269,20 @@ const ProfilePage = () => {
                 <div className="flex flex-row w-full justify-between">
                   <button
                     className="bg-goldAccents hover:bg-yellow-400 text-white font-bold py-2 px-4 rounded w-1/2"
-                    onClick={() => dispatch(setShowEditRoomPopup())}
+                    onClick={() => {
+                      dispatch(setShowEditRoomPopup());
+                      dispatch(setRoom(room));
+                    }}
                   >
                     Edit
                   </button>
-                  <button className="bg-blueSecondary hover:bg-blue-600 text-white font-bold py-2 px-4 rounded w-1/2">
+                  <button
+                    className="bg-blueSecondary hover:bg-blue-600 text-white font-bold py-2 px-4 rounded w-1/2"
+                    onClick={() => {
+                      dispatch(setRoom(room));
+                      deleteRoom();
+                    }}
+                  >
                     Delete
                   </button>
                 </div>

--- a/src/Reducers/RoomSlice.js
+++ b/src/Reducers/RoomSlice.js
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+// This slice is like UserSlice. It does on the frontend what req.session.room was supposed to do -- show which room we're in/editting/deleting.
+// This slice needs to persist through refreshes, so it does that in the store.
+
+const initialState = {
+  id: "",
+  name: "",
+  image: "",
+};
+
+export const RoomSlice = createSlice({
+  name: "room",
+  initialState,
+  reducers: {
+    setRoom: (state, action) => {
+      return action.payload;
+    },
+  },
+});
+
+export const { setRoom } = RoomSlice.actions;
+
+export default RoomSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import userReducer from "./Reducers/UserSlice";
 import profileReducer from "./Reducers/ProfilePopupSlice";
-import roomReducer from "./Reducers/RoomPopupSlice";
+import roomPopupReducer from "./Reducers/RoomPopupSlice";
 import addPlayerReducer from "./Reducers/AddPlayerPopupSlice";
 import showScenePopupReducer from "./Reducers/showScenePopupSlice";
 import showResourcePopupReducer from "./Reducers/showResourcePopupSlice";
@@ -9,6 +9,7 @@ import showCreateScenePopupReducer from "./Reducers/showCreateScenePopupSlice";
 import showAddPiecePopupReducer from "./Reducers/showAddPiecePopupSlice";
 import showEditRoomPopupReducer from "./Reducers/showEditRoomPopupSlice";
 import PieceToDropReducer from "./Reducers/PieceToDropSlice";
+import roomReducer from "./Reducers/RoomSlice";
 
 // persist imports
 import { persistStore, persistReducer } from "redux-persist";
@@ -23,14 +24,15 @@ const persistConfig = {
 };
 
 // makes the userReducer persist
-const persistedReducer = persistReducer(persistConfig, userReducer);
+const persistedUserReducer = persistReducer(persistConfig, userReducer);
+const persistedRoomReducer = persistReducer(persistConfig, roomReducer);
 
 // Standard store setup
 export const store = configureStore({
   reducer: {
-    user: persistedReducer,
+    user: persistedUserReducer,
     ProfilePopup: profileReducer,
-    RoomPopup: roomReducer,
+    RoomPopup: roomPopupReducer,
     AddPlayerPopup: addPlayerReducer,
     showScenePopup: showScenePopupReducer,
     showResourcePopup: showResourcePopupReducer,
@@ -38,6 +40,7 @@ export const store = configureStore({
     showAddPiecePopup: showAddPiecePopupReducer,
     showEditRoomPopup: showEditRoomPopupReducer,
     PiecesToDrop: PieceToDropReducer,
+    room: persistedRoomReducer,
   },
   // middleware: [thunk] // Again, thunk in case we want it.
 });


### PR DESCRIPTION
You can now edit and delete rooms from the UI. The trick is sneaking in the roomID to the backend via the Redux state.room.

There are some rehydrating issues. When a rehydrate happens, sometimes room takes on the values of user or vice versa. This can cause you to be effectively logged out.