### PR TITLE
More user feedback in creating/deleting scenes

### DIFF
--- a/src/Pages/Components/CreateScene.jsx
+++ b/src/Pages/Components/CreateScene.jsx
@@ -4,6 +4,8 @@ import { AiFillCloseCircle } from "react-icons/ai";
 import { useDispatch, useSelector } from "react-redux";
 import { setShowCreateScenePopup } from "../../Reducers/showCreateScenePopupSlice";
 import { motion } from "framer-motion";
+import { setReloadScenes } from "../../Reducers/reloadScenesSlice";
+import { toast } from "react-toastify";
 
 export const CreateScene = () => {
   const dispatch = useDispatch();
@@ -41,8 +43,23 @@ export const CreateScene = () => {
       requestOptions
     );
 
-    // refreshes the page to see the new room created
-    window.location.reload(false);
+    // This should reload the scenes
+    dispatch(setReloadScenes());
+
+    // gives the user feedback
+    toast("Scene created!", {
+      position: "top-center",
+      autoClose: 5000,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: false,
+      draggable: true,
+      progress: undefined,
+      theme: "dark",
+    });
+
+    // Closes the create scene popup
+    dispatch(setShowCreateScenePopup());
   };
 
   return (
@@ -70,6 +87,11 @@ export const CreateScene = () => {
                 name: e.target.value,
               }));
             }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                createScene();
+              }
+            }}
             type="text"
             placeholder="Scene name"
           />
@@ -79,6 +101,11 @@ export const CreateScene = () => {
                 ...sceneInfo,
                 image: e.target.value,
               }));
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                createScene();
+              }
             }}
             type="text"
             placeholder="Scene Link Here!"

--- a/src/Pages/Components/Scenes.jsx
+++ b/src/Pages/Components/Scenes.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import "./Scenes.css";
 import { MdDeleteForever } from "react-icons/md";
-import { BsFillPencilFill } from "react-icons/bs";
 import { CreateScene } from "./CreateScene";
 import { AiFillCloseCircle } from "react-icons/ai";
 // pop-up stuff
@@ -9,6 +8,7 @@ import { setShowScenePopup } from "../../Reducers/showScenePopupSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { setShowCreateScenePopup } from "../../Reducers/showCreateScenePopupSlice";
 import { motion } from "framer-motion";
+import { toast, ToastContainer } from "react-toastify";
 
 export const Scenes = () => {
   const showCreateScenePopup = useSelector(
@@ -18,6 +18,7 @@ export const Scenes = () => {
 
   // Getting the room info from state
   const room = useSelector((state) => state.persistedReducer.room);
+  const reloadScenes = useSelector((state) => state.reloadScenes);
 
   // To populate the user's rooms from the database, load in those rooms when the page loads.
   const [scenes, setScenes] = useState([]);
@@ -46,7 +47,7 @@ export const Scenes = () => {
 
   useEffect(() => {
     loadScenes();
-  }, []);
+  }, [reloadScenes]);
 
   const deleteScene = async (scene) => {
     const myHeaders = new Headers();
@@ -61,16 +62,30 @@ export const Scenes = () => {
       redirect: "follow",
     };
 
-    const deletedScene = await fetch(
+    await fetch(
       "https://plotpointsbackend.onrender.com/scenes/delete",
       requestOptions
     );
 
-    window, location.reload(false);
+    // gives the user feedback
+    toast("Scene deleted!", {
+      position: "top-center",
+      autoClose: 5000,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: false,
+      draggable: true,
+      progress: undefined,
+      theme: "dark",
+    });
+
+    // reloads the scenes list.
+    loadScenes();
   };
 
   return (
     <>
+      <ToastContainer />
       <div className="popUpCreate">
         {showCreateScenePopup && <CreateScene />}
       </div>

--- a/src/Reducers/reloadScenesSlice.js
+++ b/src/Reducers/reloadScenesSlice.js
@@ -1,0 +1,17 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = false; // This boolean is a misnomer. We actually want to reload scenes each time it changes values, not only when it is true.
+
+export const reloadScenesSlice = createSlice({
+  name: "reloadScenes",
+  initialState,
+  reducers: {
+    setReloadScenes: (state) => {
+      return !state;
+    },
+  },
+});
+
+export const { setReloadScenes } = reloadScenesSlice.actions;
+
+export default reloadScenesSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -10,6 +10,7 @@ import showAddPiecePopupReducer from "./Reducers/showAddPiecePopupSlice";
 import showEditRoomPopupReducer from "./Reducers/showEditRoomPopupSlice";
 import PieceToDropReducer from "./Reducers/PieceToDropSlice";
 import roomReducer from "./Reducers/RoomSlice";
+import reloadScenesReducer from "./Reducers/reloadScenesSlice";
 
 // persist imports
 import { persistStore, persistReducer } from "redux-persist";
@@ -44,6 +45,7 @@ export const store = configureStore({
     showEditRoomPopup: showEditRoomPopupReducer,
     PiecesToDrop: PieceToDropReducer,
     persistedReducer: persistedReducer,
+    reloadScenes: reloadScenesReducer,
   },
   // middleware: [thunk] // Again, thunk in case we want it.
 });


### PR DESCRIPTION
Toastifies, allows the user to hit enter, and more. -When you create a scene, instead of totally refreshing the page, a toastify pops up and loadScenes in Scenes.jsx re-runs via a Redux variable. Similar changes for deleting a scene.